### PR TITLE
Feature/12 result page

### DIFF
--- a/app/assets/stylesheets/steps.css
+++ b/app/assets/stylesheets/steps.css
@@ -32,14 +32,26 @@ body {
   font-size: 14px;
   color: #666;
 }
-form {
+.main-form {
   max-width: 600px;
   margin: 0 auto;
   background-color: #ffffff;
   padding: 28px;
+  border-radius: 20px;
+  border: 1.5px solid #f3d5b5;
+  box-shadow: 0 4px 16px rgba(231, 111, 81, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
+}
+
+.form-group:first-of-type textarea.form-control {
+  color: #5a3e2b;
+  background-color: #fffef5;
+  border: 2px dashed #f4a261;
   border-radius: 16px;
-  border: 1px solid #e8d8c3;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+  box-shadow: 3px 3px 0px #f3d5b5;
+  line-height: 1.6;
+  padding: 14px;
+
+  background-image: none;
 }
 
 .form-control, textarea {
@@ -59,7 +71,11 @@ form {
 }
 
 .form-group { margin-bottom: 32px; }
-.form-actions { margin-top: 40px; }
+
+.form-actions {
+  margin-top: 40px;
+  text-align: center; 
+  }
 
 label {
   display: block;
@@ -79,13 +95,14 @@ label {
   min-width: 120px;
   padding: 12px 10px;
   border-radius: 999px;
-  border: 1px solid #e5e5e5;
-  background: #fff;
+  border: 1.5px solid #e8d8c3;
+  background: #fffaf7;
   cursor: pointer;
   font-size: 12px;
   transition: all 0.2s;
   color: #444;
   gap: 10px;
+  font-weight: 500;
 }
 
 
@@ -93,6 +110,7 @@ label {
   transform: translateY(-1px);
   background: #fff7f0;
   border-color: #f4a261;
+  color: #c1440e;
 }
 
 .status-btn.active {
@@ -105,12 +123,12 @@ label {
 .btn {
   background: linear-gradient(135deg, #f4a261, #e76f51);
   color: white;
-  padding: 14px 20px;
+  padding: 12px 18px;
   border: none;
   border-radius: 999px;
   cursor: pointer;
   font-size: 15px;
-  width: 100%;
+  width: auto;
   transition: 0.2s;
 }
 
@@ -122,10 +140,10 @@ label {
 .header {
   background: #e76f51;
   color: white;
-  padding: 30px 16px;
+  padding: 20px 16px;
   font-weight: bold;
   text-align: center;
-  margin-bottom: 50px;
+  margin-bottom: 0;
   border-radius: 0;
 
 }
@@ -135,7 +153,7 @@ label {
   align-items: center;
   gap: 16px;
   max-width: 600px;
-  margin: 0 auto 24px;
+  margin: 0 auto 16px;
 }
 
 .mascot-bubble {
@@ -168,6 +186,60 @@ label {
 }
 
 .mascot-img {
-  width: 110px;
+  width: 120px;
   height: auto;
+}
+
+
+/*result画面*/
+
+.result-card {
+  max-width: 600px;
+  margin: 0 auto;
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 4px 16px rgba(231, 111, 81, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
+  border: 1.5px solid #f3d5b5;
+  border-radius: 20px;
+}
+
+.proposal-content {
+  background: #fff7f0;
+  border-left: 4px solid #f4a261;
+  padding: 20px;
+  margin-bottom: 24px;
+  line-height: 1.8;
+  font-size: 15px;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+/* result内のformだけリセット */
+.action-buttons form {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: #e76f51;
+  border: 1px solid #e76f51;
+}
+
+.result-header {
+  text-align: center;
+}
+
+.result-header h2 {
+  font-size: 20px;
+  margin-bottom: 16px;
 }

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,16 +1,53 @@
 class StepsController < ApplicationController
-  def top
+  include StepsHelper
+  
+  def new
   end
 
-  def create
+  def generate
     @goal = params[:step][:goal]
-    @reason = params[:step][:reason]
-    @status = params[:step][:status]
+    @feeling = params[:step][:feeling]
+    @time_available = params[:step][:time_available]
+    @blocker = params[:step][:blocker]
 
     Rails.logger.debug "Goal: #{@goal}"
-    Rails.logger.debug "Reason: #{@reason}"
-    Rails.logger.debug "Status: #{@status}"
+    Rails.logger.debug "Feeling: #{@feeling}"
+    Rails.logger.debug "Time Available: #{@time_available}"
+    Rails.logger.debug "Blocker: #{@blocker}"
 
+    # AI統合前は固定の提案文を生成
+    @proposal = build_mock_proposal
     render  :result
+  end
+
+# 開発用: 結果画面を直接確認するアクション
+  def result
+    # テスト用のダミーデータ
+    @goal = "朝のランニングを始める"
+    @feeling = "light_interest"
+    @time_available = "30min"
+    @blocker = "lazy_friction"
+    @proposal = build_mock_proposal
+  end
+
+  private
+
+  def build_mock_proposal
+    <<~TEXT
+      🌱 今日の一歩
+
+      「#{@goal}」に興味があるんですね!
+      
+      #{feeling_message(@feeling)}
+      
+      使える時間は#{time_message(@time_available)}ですね。
+      それなら、こんな小さな一歩はどうでしょう？
+
+      ・スマホのメモに「やってみたいこと」を1つ書く
+
+      #{blocker_message(@blocker)}
+
+      小さなことでも大丈夫。一緒に進めていきましょう 🌱
+    TEXT
   end
 end

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -1,2 +1,44 @@
 module StepsHelper
+  
+  def feeling_message(feeling_value)
+    case feeling_value
+    when 'light_interest'
+      '「ちょっと変わりたい」という気持ち、素敵ですね!'
+    when 'strong_interest'
+      '気になっているということは、心のどこかで興味があるんですね。'
+    when 'blocked_action'
+      '動きたい気持ちはあるのに重く感じる...その気持ち、よくわかります。'
+    when 'unclear_state'
+      'モヤモヤしている時こそ、小さな行動が助けになりますよ。'
+    else
+      ''
+    end
+  end
+
+  def time_message(time_available)
+    case time_available
+    when '5min' then '5分'
+    when '30min' then '30分'
+    when '60min_plus' then '1時間以上'
+    else time_available
+    end
+  end
+
+  def blocker_message(blocker_value)
+    return '' if blocker_value.blank?
+    
+    case blocker_value
+    when 'tired'
+      '疲れている時は、無理しなくて大丈夫。できる範囲で。'
+    when 'unclear_how'
+      'やり方がわからない時は、まず情報を集めることから始めましょう。'
+    when 'lazy_friction'
+      'めんどくさい気持ち、わかります。だからこそ、超簡単なことから。'
+    when 'low_energy'
+      'やる気が出ない日もあります。そんな日は、ほんの少しだけでOK。'
+    else
+      ''
+    end
+  end
+
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -27,7 +27,7 @@ const initStepForm = () => {
   });
 
   // フォーム送信時の処理
-  const form = document.querySelector('form');
+  const form = document.querySelector('.main-form');
   if (!form) return;
 
   // エラー表示用の関数

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <link href="https://fonts.googleapis.com/css2?family=Zen+Kurenaido&display=swap" rel="stylesheet">
   </head>
 
   <body>

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -3,6 +3,14 @@
       まよまよステップ
     </div>
 
+    <svg style="display:block; width:100%; height:28px; margin-top:-1px;"
+       viewBox="0 0 480 28" preserveAspectRatio="none"
+       xmlns="http://www.w3.org/2000/svg">
+      <path d="M0,0 C40,0 40,24 80,24 C120,24 120,4 160,4 C200,4 200,24 240,24
+           C280,24 280,4 320,4 C360,4 360,24 400,24 C440,24 440,4 480,4 L480,0 Z"
+        fill="#e76f51"/>
+    </svg>
+
     <div class="mascot-area">
       <div class="mascot">
         <%= image_tag "mayomayo.png", class: "mascot-img" %>
@@ -18,7 +26,7 @@
        </div>
     </div>
   
-  <%= form_with url: steps_path, method: :post, local: true do |f| %>
+  <%= form_with url: generate_step_path, method: :post, scope: :step, local: true, class: "main-form" do |f| %>
     <div class="form-group">
       <%= f.label :goal, class: 'form-label' do %>
          🌱気になっていること

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -48,7 +48,7 @@
         <% end %>
         <%= f.hidden_field :feeling, id: "feeling-field" %>
       
-      <div class="status-buttons">
+      <div class="status-buttons" data-target="feeling-field">
         <button type="button" class="status-btn" data-value="light_interest">
           ちょっと変わりたい
         </button>
@@ -74,7 +74,7 @@
        <% end %>
        <%= f.hidden_field :time_available, id: "time-available-field" %>
       
-      <div class="status-buttons">
+      <div class="status-buttons" data-target="time-available-field">
         <button type="button" class="status-btn" data-value="5min">
           5分
         </button>
@@ -95,7 +95,7 @@
        <% end %>
        <%= f.hidden_field :blocker, id: "blocker-field" %>
       
-      <div class="status-buttons">
+      <div class="status-buttons" data-target="blocker-field">
         <button type="button" class="status-btn" data-value="tired">
           疲れてる
         </button>

--- a/app/views/steps/result.html.erb
+++ b/app/views/steps/result.html.erb
@@ -1,0 +1,47 @@
+<div class="container result-container">
+  <div class="header">
+    まよまよステップ
+  </div>
+
+  <svg style="display:block; width:100%; height:28px; margin-top:-1px;"
+       viewBox="0 0 480 28" preserveAspectRatio="none"
+       xmlns="http://www.w3.org/2000/svg">
+      <path d="M0,0 C40,0 40,24 80,24 C120,24 120,4 160,4 C200,4 200,24 240,24
+           C280,24 280,4 320,4 C360,4 360,24 400,24 C440,24 440,4 480,4 L480,0 Z"
+        fill="#e76f51"/>
+  </svg>
+
+  <div class="mascot-area">
+    <div class="mascot">
+      <%= image_tag "mayomayo.png", class: "mascot-img" %>
+    </div>
+    <div class="mascot-bubble result-bubble">
+      <p class="bubble-title">
+        今日の一歩を見つけたよ!
+      </p>
+    </div>
+  </div>
+
+  <div class="result-card">
+    <div class="result-header">
+      <h2>🌱 あなたへの提案</h2>
+    </div>
+    
+    <div class="proposal-content">
+      <%= simple_format(@proposal) %>
+    </div>
+
+    <div class="action-buttons">
+      <%= form_with url: generate_step_path, method: :post do %>
+        <%= hidden_field_tag :goal, @goal %>
+        <%= hidden_field_tag :feeling, @feeling %>
+        <%= hidden_field_tag :time_available, @time_available %>
+        <%= hidden_field_tag :blocker, @blocker %>
+
+        <%= submit_tag "もう一度提案する", class: "btn btn-primary" %>
+     <% end %>
+      
+      <%= link_to '新しく相談する', root_path, class: 'btn btn-primary' %>
+    </div>
+  </div>
+</div>

--- a/app/views/steps/result.html.erb
+++ b/app/views/steps/result.html.erb
@@ -33,10 +33,10 @@
 
     <div class="action-buttons">
       <%= form_with url: generate_step_path, method: :post do %>
-        <%= hidden_field_tag :goal, @goal %>
-        <%= hidden_field_tag :feeling, @feeling %>
-        <%= hidden_field_tag :time_available, @time_available %>
-        <%= hidden_field_tag :blocker, @blocker %>
+        <%= hidden_field_tag "step[goal]", @goal %>
+        <%= hidden_field_tag "step[feeling]", @feeling %>
+        <%= hidden_field_tag "step[time_available]", @time_available %>
+        <%= hidden_field_tag "step[blocker]", @blocker %>
 
         <%= submit_tag "もう一度提案する", class: "btn btn-primary" %>
      <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
-  root 'steps#top'
-  post 'steps', to: 'steps#create'
+  root 'steps#new'
+  post 'steps/generate', to: 'steps#generate', as: 'generate_step'
+  get 'steps/result', to: 'steps#result'
 end


### PR DESCRIPTION
## 概要
結果画面のレイアウトとスタイリングを実装しました。
ユーザーが入力した内容に基づいてメッセージが表示されるようになります。

## 変更内容
- 結果表示用のビュー（result.html.erb）を追加
- フォーム入力値を受け取り、提案文を生成する処理をコントローラに実装
- 提案文の一部（気持ち・時間・阻害要因）をヘルパーで分岐して表示するように実装
- 同じ入力内容で再度提案を生成できる「もう一度提案する」機能を追加
- 結果画面のUIを調整

## 実装の意図
- MVPでは「気軽に入力 → 小さな一歩の提案を得る体験」を重視しているため、データベースには保存せず、その場で提案を生成する構成にしています
- 入力内容を保持したまま再提案できるようにすることで、ユーザーが複数の選択肢を試しやすくしています
- 表示ロジックをヘルパーに分離することで、今後AI生成に置き換える際も影響範囲を限定できるようにしています

## 変更ファイル
- `app/views/steps/result.html.erb`
- `app/assets/stylesheets/application.css`
- `app/helpers/steps_helper.rb`
- `app/controllers/steps_controller.rb`
- `config/routes.rb`
- `app/views/layouts/application.html.erb`
