### PR TITLE
バリデーションエラーの追加

### DIFF
--- a/app/assets/stylesheets/steps.css
+++ b/app/assets/stylesheets/steps.css
@@ -42,7 +42,7 @@ body {
   box-shadow: 0 4px 16px rgba(231, 111, 81, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
 }
 
-.form-group:first-of-type textarea.form-control {
+.goal-group textarea.form-control {
   color: #5a3e2b;
   background-color: #fffef5;
   border: 2px dashed #f4a261;
@@ -50,7 +50,6 @@ body {
   box-shadow: 3px 3px 0px #f3d5b5;
   line-height: 1.6;
   padding: 14px;
-
   background-image: none;
 }
 
@@ -242,4 +241,18 @@ label {
 .result-header h2 {
   font-size: 20px;
   margin-bottom: 16px;
+}
+
+.alert {
+  background: #fff4f4;
+  color: #cc4444;
+  margin-top: -8px;
+  margin-bottom: 16px; 
+  padding: 12px;
+  border-radius: 8px;  
+}
+
+.alert ul {
+  padding-left: 0;
+  list-style: none;
 }

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -2,22 +2,24 @@ class StepsController < ApplicationController
   include StepsHelper
   
   def new
+    @step = Step.new
   end
 
   def generate
-    @goal = params[:step][:goal]
-    @feeling = params[:step][:feeling]
-    @time_available = params[:step][:time_available]
-    @blocker = params[:step][:blocker]
+    @step = Step.new(step_params)
 
-    Rails.logger.debug "Goal: #{@goal}"
-    Rails.logger.debug "Feeling: #{@feeling}"
-    Rails.logger.debug "Time Available: #{@time_available}"
-    Rails.logger.debug "Blocker: #{@blocker}"
+   if @step.valid?
+    @goal = @step.goal
+    @feeling = @step.feeling
+    @time_available = @step.time_available
+    @blocker = @step.blocker
 
     # AI統合前は固定の提案文を生成
     @proposal = build_mock_proposal
     render  :result
+   else
+    render :new, status: :unprocessable_entity
+   end
   end
 
 # 開発用: 結果画面を直接確認するアクション
@@ -31,6 +33,10 @@ class StepsController < ApplicationController
   end
 
   private
+
+  def step_params
+    params.require(:step).permit(:goal, :feeling, :time_available, :blocker)
+  end
 
   def build_mock_proposal
     <<~TEXT

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -30,43 +30,7 @@ const initStepForm = () => {
   const form = document.querySelector('.main-form');
   if (!form) return;
 
-  // エラー表示用の関数
-  const showError = (message) => {
-    let errorEl = document.getElementById('form-error');
-    if (!errorEl) {
-      errorEl = document.createElement('p');
-      errorEl.id = 'form-error';
-      errorEl.style.cssText = 'color:#e76f51; font-size:14px; margin-bottom:12px; text-align:center;';
-      form.prepend(errorEl);
-    }
-    errorEl.textContent = message;
-    errorEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  };
-
-  // エラーをクリアする関数
-  const clearError = () => {
-    const errorEl = document.getElementById('form-error');
-    if (errorEl) errorEl.textContent = '';
-  };
-
   form.addEventListener('submit', (e) => {
-    clearError();
-
-    const goal = document.querySelector('textarea[name="step[goal]"]');
-    const feeling = document.getElementById('feeling-field');
-    const timeAvailable = document.getElementById('time-available-field');
-
-    if (!goal || !goal.value.trim()) {
-      e.preventDefault();
-      showError('「気になっていること」を入力してください');
-      return;
-    }
-
-    if (!feeling?.value || !timeAvailable?.value) {
-      e.preventDefault();
-      showError('「今の気持ち」と「今から使える時間」を選択してください');
-      return;
-    }
 
     // バリデーション通過後：二重送信対策
     const submitBtn = form.querySelector('[type="submit"]');

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,0 +1,38 @@
+class Step
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :goal, :string
+  attribute :feeling, :string
+  attribute :time_available, :string
+  attribute :blocker, :string
+
+  validates :goal, presence: { message: 'を入力してください' }, 
+                   length: { maximum: 500, message: '500文字以内で入力してください' }
+  validates :feeling, presence: { message: 'を選択してください' },
+                      inclusion: { in: %w[light_interest strong_interest blocked_action unclear_state], message: '正しい気持ちを選択してください',  allow_blank: true}
+  validates :time_available, presence: { message: 'を選択してください' },
+                             inclusion: { in: %w[5min 30min 60min_plus], allow_blank: true}               
+  validates :blocker, inclusion: { in: %w[tired unclear_how lazy_friction low_energy], allow_blank: true, message: '正しい項目を選択してください' }
+
+  FEELINGS = {
+    'light_interest' => 'ちょっと変わりたい',
+    'strong_interest' => '気になっているだけ',
+    'blocked_action' => '動きたいけど重い',
+    'unclear_state' => 'なんとなくモヤモヤ'
+  }.freeze
+
+  TIME_AVAILABLE_OPTIONS = {
+    '5min' => '5分',
+    '30min' => '30分',
+    '60min_plus' => '1時間以上'
+  }.freeze
+
+  BLOCKERS = {
+    'tired' => '疲れている',
+    'unclear_how' => 'やり方がわからない',
+    'lazy_friction' => 'めんどくさい',
+    'low_energy' => 'やる気が出ない'
+    }.freeze
+
+end

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -20,14 +20,26 @@
           やりたい気持ちはあるのに、なかなか動けないときに
         </p>
         <p class="bubble-text">
-         「今日これならできそう」と思える一歩を、まよまよが提案します。<br>
-          小さなことでも大丈夫。一緒に考えよう🌱
+         「今日これならできそう」と思える一歩を<br>まよまよが提案します。<br>
+           小さなことでも大丈夫。一緒に考えよう🌱
         </p>
        </div>
     </div>
   
   <%= form_with url: generate_step_path, method: :post, scope: :step, local: true, class: "main-form" do |f| %>
-    <div class="form-group">
+    
+    <% if @step.errors.any? %>
+      <div class='alert alert-danger'>
+        <ul>
+          <% @step.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    
+    
+    <div class="form-group goal-group">
       <%= f.label :goal, class: 'form-label' do %>
          🌱気になっていること
           <span class="required-badge">(必須)</span>
@@ -37,7 +49,6 @@
           class: 'form-control',
           rows: 4, 
           placeholder: '例：英語やり直したい気がしてる、運動したほうがいいかなと思ってる、新しいことに少し興味ある', 
-          required: true,
           'aria-required': 'true' %>
     </div>
 
@@ -49,21 +60,13 @@
         <%= f.hidden_field :feeling, id: "feeling-field" %>
       
       <div class="status-buttons" data-target="feeling-field">
-        <button type="button" class="status-btn" data-value="light_interest">
-          ちょっと変わりたい
-        </button>
-
-        <button type="button" class="status-btn" data-value="strong_interest">
-          気になっているだけ
-        </button>
-
-        <button type="button" class="status-btn" data-value="blocked_action">
-          動きたいけど重い
-        </button>
-
-        <button type="button" class="status-btn" data-value="unclear_state">
-          なんとなくモヤモヤ
-        </button>
+        <% Step::FEELINGS.each do |key, label| %>
+          <button type="button" 
+            class="status-btn <%= 'active' if @step.feeling == key %>"
+            data-value="<%= key %>">
+            <%= label %>
+          </button>
+        <% end %>
       </div>
     </div>
     
@@ -75,17 +78,13 @@
        <%= f.hidden_field :time_available, id: "time-available-field" %>
       
       <div class="status-buttons" data-target="time-available-field">
-        <button type="button" class="status-btn" data-value="5min">
-          5分
-        </button>
-
-        <button type="button" class="status-btn" data-value="30min">
-          30分
-        </button>
-
-        <button type="button" class="status-btn" data-value="60min_plus">
-          1時間～
-        </button>
+        <% Step::TIME_AVAILABLE_OPTIONS.each do |key, label| %>
+          <button type="button"
+            class="status-btn <%= 'active' if @step.time_available == key %>"
+            data-value="<%= key %>">
+            <%= label %>
+          </button>
+        <% end %>
       </div>
     </div>
 
@@ -96,21 +95,13 @@
        <%= f.hidden_field :blocker, id: "blocker-field" %>
       
       <div class="status-buttons" data-target="blocker-field">
-        <button type="button" class="status-btn" data-value="tired">
-          疲れてる
-        </button>
-
-        <button type="button" class="status-btn" data-value="unclear_how">
-          やり方がわからない
-        </button>
-
-        <button type="button" class="status-btn" data-value="lazy_friction">
-          めんどくさい
-        </button>
-
-        <button type="button" class="status-btn" data-value="low_energy">
-          なんとなくやる気出ない
-        </button>
+       <% Step::BLOCKERS.each do |key, label| %>
+          <button type="button"
+            class="status-btn <%= 'active' if @step.blocker == key %>"
+            data-value="<%= key %>">
+            <%= label %>
+          </button>
+        <% end %> 
       </div>
     </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module App
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  activemodel:
+    attributes:
+      step:
+        goal: '気になっていること'
+        feeling: '今の気持ち'
+        time_available: '今から使える時間'
+        blocker: '動けない理由'
+   


### PR DESCRIPTION
## 概要
StepForm にバリデーションを実装しました。

また、選択肢の定義をモデルに集約し、ビューの重複コードを削減しました。


## 背景・目的
- OpenAI API に送信する前に、ユーザー入力データの妥当性を検証する必要がある
- 不正なデータが API に送信されるのを防ぐため
- バリデーションをモデルに集約することで、データの整合性を担保するため
- 選択肢をモデルの定数として定義することで、ビューとバリデーションの不整合を防ぐため
- ループでボタンを生成することで、重複コードを削減し保守性を向上させるため


### 追加したバリデーション
- goal: 必須入力、500文字以内
- feeling: 必須入力、定数 FEELINGS に定義された値のみ許可
- time_available: 必須入力、定数 TIME_AVAILABLE_OPTIONS に定義された値のみ許可
- blocker: 任意入力、定数 BLOCKERS に定義された値のみ許可


## 変更内容
- Stepモデルにバリデーションを追加
- generateアクションでバリデーションを実行するよう修正
- バリデーションエラー時にフォームを再表示するよう修正
- エラーメッセージをビューに表示する処理を追加
- form_with を modelベースに変更し、入力値を保持できるように修正
- 選択ボタン（feeling / time / blocker）をループで生成するように変更
- モデルに定数を定義
- バリデーションエラー時に選択状態が保持されるように修正


## 変更ファイル
- `app/models/step_form.rb`
- `app/controllers/step_controller.rb`
- `config/locales/ja.yml`
- `app/views/steps/new.html.rb`
- `app/assets/stylesheets/steps.css`
- `app/javascript/application.js`