### PR TITLE
feat: OpenAI APIの初期設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,12 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'ruby-openai'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,9 +106,22 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
+    event_stream_parser (1.0.0)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -126,6 +139,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    json (2.19.3)
     logger (1.7.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
@@ -143,7 +157,10 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
     mutex_m (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.3)
       date
       net-protocol
@@ -216,6 +233,10 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
+    ruby-openai (8.3.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     rubyzip (3.2.2)
     securerandom (0.4.1)
     selenium-webdriver (4.41.0)
@@ -243,6 +264,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.1.1)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -264,11 +286,13 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)
+  ruby-openai
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,0 +1,3 @@
+OpenAI.configure do |config|
+  config.access_token = ENV['OPENAI_API_KEY']
+end


### PR DESCRIPTION
## 概要
OpenAIのAPIを使用するための初期設定を追加しました。

## 変更内容
- OpenAIのAPIキーを取得
- .envファイルの作成し、APIキーを環境変数として管理
- `ruby-openai` gem を追加
- OpenAIの初期化設定ファイル (`config/initializers/openai.rb`) を作成


## 変更ファイル
- `Gemfile` / `Gemfile.lock` : `ruby-openai` gem を追加
- `config/initializers/openai.rb` : OpenAI APIクライアントの初期化設定


## 確認事項
- [x] `.env` ファイルが `.gitignore` に追加されており、Gitに含まれていないことを確認
- [x] `bundle install` が正常に完了
- [x] Railsサーバーが正常に起動することを確認