### PR TITLE
feat: generateコントローラ・プロンプト作成・リトライボタン修正

### DIFF
--- a/app/assets/stylesheets/steps.css
+++ b/app/assets/stylesheets/steps.css
@@ -256,3 +256,35 @@ label {
   padding-left: 0;
   list-style: none;
 }
+
+/* まよまよの吹き出し内の例 */
+.examples-intro {
+  font-size: 13px;
+  font-weight: 600;
+  color: #666;
+  margin-top: 16px;
+  margin-bottom: 8px;
+  padding-top: 16px;
+  border-top: 1px dashed #f3d5b5;
+}
+
+.examples-simple-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  font-size: 13px;
+  color: #777;
+}
+
+.examples-simple-list li {
+  padding: 4px 0;
+  position: relative;
+  padding-left: 16px;
+}
+
+.examples-simple-list li::before {
+  content: "・";
+  position: absolute;
+  left: 0;
+  color: #f4
+}

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,5 +1,4 @@
 class StepsController < ApplicationController
-  include StepsHelper
   
   def new
     @step = Step.new
@@ -8,28 +7,24 @@ class StepsController < ApplicationController
   def generate
     @step = Step.new(step_params)
 
-   if @step.valid?
-    @goal = @step.goal
-    @feeling = @step.feeling
-    @time_available = @step.time_available
-    @blocker = @step.blocker
+    if @step.valid?
+      is_retry = params[:is_retry]
+      previous = params[:previous_proposal]
 
-    # AI統合前は固定の提案文を生成
-    @proposal = build_mock_proposal
-    render  :result
-   else
-    render :new, status: :unprocessable_entity
-   end
-  end
-
-# 開発用: 結果画面を直接確認するアクション
-  def result
-    # テスト用のダミーデータ
-    @goal = "朝のランニングを始める"
-    @feeling = "light_interest"
-    @time_available = "30min"
-    @blocker = "lazy_friction"
-    @proposal = build_mock_proposal
+      ai = AiGenerator.new
+      @proposal = ai.generate(
+        goal: @step.goal,
+        feeling: @step.feeling,
+        time_available: @step.time_available,
+        blocker: @step.blocker,
+        is_retry: params[is_retry],
+        previous_proposal: params[previous]
+      )
+      @proposal ||= build_mock_proposal
+      render  :result
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   private
@@ -38,22 +33,7 @@ class StepsController < ApplicationController
     params.require(:step).permit(:goal, :feeling, :time_available, :blocker)
   end
 
-  def build_mock_proposal
-    <<~TEXT
-      🌱 今日の一歩
-
-      「#{@goal}」に興味があるんですね!
-      
-      #{feeling_message(@feeling)}
-      
-      使える時間は#{time_message(@time_available)}ですね。
-      それなら、こんな小さな一歩はどうでしょう？
-
-      ・スマホのメモに「やってみたいこと」を1つ書く
-
-      #{blocker_message(@blocker)}
-
-      小さなことでも大丈夫。一緒に進めていきましょう 🌱
-    TEXT
+  def retry_params
+    params.permit(:is_retry, :previous_proposal)
   end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -12,12 +12,12 @@ class Step
   validates :feeling, presence: { message: 'を選択してください' },
                       inclusion: { in: %w[light_interest strong_interest blocked_action unclear_state], message: '正しい気持ちを選択してください',  allow_blank: true}
   validates :time_available, presence: { message: 'を選択してください' },
-                             inclusion: { in: %w[5min 30min 60min_plus], allow_blank: true}               
+                             inclusion: { in: %w[5min 30min 60min_plus], allow_blank: true, message: '正しい時間を選択してください'}               
   validates :blocker, inclusion: { in: %w[tired unclear_how lazy_friction low_energy], allow_blank: true, message: '正しい項目を選択してください' }
 
   FEELINGS = {
-    'light_interest' => 'ちょっと変わりたい',
-    'strong_interest' => '気になっているだけ',
+    'light_interest' => '気になっているだけ',
+    'strong_interest' => 'ちょっと変わりたい',
     'blocked_action' => '動きたいけど重い',
     'unclear_state' => 'なんとなくモヤモヤ'
   }.freeze

--- a/app/services/ai_generator.rb
+++ b/app/services/ai_generator.rb
@@ -3,29 +3,117 @@ class AiGenerator
      @client = OpenAI::Client.new
   end
 
-  def generate(goal:, feeling:, time_available:, blocker:)
+  def generate(goal:, feeling:, time_available:, blocker:, is_retry: false, previous_proposal: nil)
      prompt = build_prompt(
        goal: goal, 
        feeling: feeling, 
        time_available: time_available, 
-       blocker: blocker  
+       blocker: blocker,
+       is_retry: is_retry,
+       previous_proposal: previous_proposal 
      )
      call_api(prompt)
   end
       
   private
 
-  def build_prompt(goal:, feeling:, time_available:, blocker:)
+  def build_prompt(goal:, feeling:, time_available:, blocker:, is_retry:, previous_proposal:)
+    feeling_text = Step::FEELINGS[feeling]
+    time_text = Step::TIME_AVAILABLE_OPTIONS[time_available]
+    blocker_text = Step::BLOCKERS[blocker]
+
+    feeling_guidance = case feeling
+                   when 'blocked_action'
+                     '行動したい気持ちはあるので、背中を押すような提案をしてください'
+                   when 'unclear_state'
+                     'モヤモヤしているので、とにかく手を動かせる提案をしてください'
+                   when 'light_interest'
+                     'まだ興味段階なので、負担ゼロの提案をしてください'
+                   when 'strong_interest'
+                     'かなりやる気があるので、少し踏み込んだ提案をしてください'
+                   end
+ 
+    action_depth = case time_available
+                    when '5min' 
+                      '超簡単な準備や情報収集（アプリをインストール、1つの記事をブックマーク）'
+                    when '30min'
+                      '実際に手を動かす行動（動画を見る、簡単な練習をする）'
+                    when '60min_plus'
+                      'じっくり取り組む行動（実際に作ってみる、複数の情報を比較する）'
+                    end
+
+    blocker_guidance = case blocker
+                       when 'tired'
+                          '疲れている人向けに、頭を使わない簡単な行動を提案してください'
+                       when 'unclear_how'
+                          '何から始めればいいか分からない人向けに、最初の一歩を明確に示してください'
+                       when 'lazy_friction'
+                          'めんどくさがりな人向けに、超簡単でハードルの低い行動を提案してください'
+                       when 'low_energy'
+                          'やる気が出ない人向けに、楽しそうな行動を提案してください'
+                       else
+                          ''
+                       end
+
+    previous_text = if is_retry && previous_proposal.present?
+                     "前回の提案: #{previous_proposal}"
+                    else
+                     ""
+                    end
+
+    is_retry_instruction = if is_retry
+                         "前回の提案と同じ行動は絶対に提案しないこと。異なるアプローチで提案すること。"
+                        else
+                         ""
+                        end
+
     <<~PROMPT
       ユーザーの情報:
       - やりたいこと・気になること: #{goal}
-      - 今の気持ち: #{feeling}
-      - 使える時間: #{time_available}
-      - 邪魔しているもの: #{blocker.presence || "特になし"}
+      - 今の気持ち: #{feeling_text}
+      #{feeling_guidance}
+      - 使える時間: #{time_text}
+      - 行動レベル: #{action_depth}
+      - 邪魔しているもの: #{blocker.present? ? blocker_text : "特になし"}
+                         #{blocker_guidance}
+       #{is_retry_instruction}
+       #{previous_text}
+      
+      今日やる行動を1つだけ提案してください。
+      行動のみを出力してください。
 
-      上記をもとに、今日できる小さな一歩を一つだけ提案してください。
-      優しく、具体的に、100～150文字程度でお願いします。
-    PROMPT
+
+     【ルール】
+     - 「〜してみませんか？」という提案形式
+     - 100文字以内
+     - 「対象 + 数量 + 動作」で具体化する
+     - 迷いなく即実行できる内容にする
+     - 必要なら検索ワードと参照範囲を指定する
+     - 手を動かす行動に限定する（視聴・受講はNG）
+     - ユーザーが自分の手や頭を使う行動に限定する
+     - 時間に合った現実的な提案をする
+     - 誰でもすぐ実行できるレベルにする
+     - ユーザーが考えなくていいレベルまで分解すること
+     - 「何をするか」が一意に決まる形にすること 
+     - 特定の環境（自宅に〇〇がある前提など）に依存しない行動にする
+     - 同じ種類の行動（例：書く）に偏らないようにする
+
+     【NG例】
+     - 抽象的（例：勉強する・運動する）
+     - 動画を見る・講座を受ける
+     - 曖昧な表現（少し・軽く）
+
+     【検索系の行動を提案する場合】
+     - 検索ワードを具体的に指定する（「」で囲む）
+     - 検索後に何をするか明確にする
+      例：「見出しだけ読む」「画像を1つ保存する」「最初の段落だけメモする」
+     - 「YouTube」「Google」だけで終わらせない
+ 
+     【具体例】
+      - 栄養について勉強したい → 「今日食べたものを3つ書いて、それぞれに含まれる栄養素を1つ考えてみませんか？」
+      - 栄養について勉強したい →「『五大栄養素とは』と検索して、出てきた説明の最初の1段落だけ読んでみませんか？」
+      - 植物について詳しくなりたい → 「自宅にある植物の名前を3つ調べて、それぞれの育て方をメモしてみませんか？」
+     PROMPT
   end
 
   def call_api(prompt)
@@ -36,7 +124,7 @@ class AiGenerator
            { role: "system", content: system_prompt },
            { role: "user", content: prompt}
          ],
-         temperature:0.7
+         temperature:0.5
         }
       )
         response.dig("choices", 0, "message", "content")
@@ -47,8 +135,10 @@ class AiGenerator
     end
   
   def system_prompt
-    "あなたは「まよまよ」という優しいコーチです。"\
-    "行動できずに迷っている人に寄り添い、今日できる小さな一歩を提案します。"\
-    "押し付けず、温かく、具体的な言葉で話しかけてください。"
+    <<~SYSTEM
+      あなたは、ユーザーのやりたいことを達成するための具体的な行動を提案する優秀なアシスタントです。
+      余計な説明や励ましはせず、シンプルに行動のみを提示してください。
+      ユーザーの情報をもとに、今日できる具体的な行動を一つだけ提案してください。
+    SYSTEM
   end
 end

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -15,15 +15,23 @@
       <div class="mascot">
         <%= image_tag "mayomayo.png", class: "mascot-img" %>
       </div>
+
       <div class="mascot-bubble">
         <p class="bubble-title">
-          やりたい気持ちはあるのに、なかなか動けないときに
+          まよまよステップへようこそ！
         </p>
-        <p class="bubble-text">
-         「今日これならできそう」と思える一歩を<br>まよまよが提案します。<br>
-           小さなことでも大丈夫。一緒に考えよう🌱
-        </p>
-       </div>
+          <p class="bubble-text">
+            やりたいことはあるのに、なかなか動き出せない...<br>
+            そんなときに、今日の一歩を提案するサービスです🌱
+          </p>
+      
+         <p class="examples-intro">例えば、こんな気になっていることを教えてね：</p>
+           <ul class="examples-simple-list">
+               <li>料理がうまくなりたい</li>
+               <li>栄養について勉強したい</li>
+               <li>刺繍を始めてみたい</li>
+            </ul>
+      </div>
     </div>
   
   <%= form_with url: generate_step_path, method: :post, scope: :step, local: true, class: "main-form" do |f| %>
@@ -48,7 +56,7 @@
       <%= f.text_area :goal, 
           class: 'form-control',
           rows: 4, 
-          placeholder: '例：英語やり直したい気がしてる、運動したほうがいいかなと思ってる、新しいことに少し興味ある', 
+          placeholder: 'ここに書いてね', 
           'aria-required': 'true' %>
     </div>
 

--- a/app/views/steps/result.html.erb
+++ b/app/views/steps/result.html.erb
@@ -33,10 +33,14 @@
 
     <div class="action-buttons">
       <%= form_with url: generate_step_path, method: :post do %>
-        <%= hidden_field_tag "step[goal]", @goal %>
-        <%= hidden_field_tag "step[feeling]", @feeling %>
-        <%= hidden_field_tag "step[time_available]", @time_available %>
-        <%= hidden_field_tag "step[blocker]", @blocker %>
+        <%= hidden_field_tag "step[goal]", @step.goal %>
+        <%= hidden_field_tag "step[feeling]", @step.feeling %>
+        <%= hidden_field_tag "step[time_available]", @step.time_available %>
+        <%= hidden_field_tag "step[blocker]", @step.blocker %>
+
+        <%= hidden_field_tag "is_retry", true %>
+        <%= hidden_field_tag "previous_proposal", @proposal %>
+
 
         <%= submit_tag "もう一度提案する", class: "btn btn-primary" %>
      <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module App
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
     config.i18n.default_locale = :ja
-
+    config.autoload_paths << Rails.root.join("app/services")
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## 概要
AIによる行動提案機能を実装し、再提案時に異なるアプローチが出るよう改善しました。  
また、実際に触ってみた結果をもとに、入力フォームと出力UIの見直し方針を整理しました。

---

## 実装内容
- `generate`アクションの実装（StepsController）
- プロンプト設計
- 「もう一度提案する」機能の改善
  - 前回と異なる提案を出すように修正

---


## コントローラ
- StepsController#generate を実装
- バリデーション成功時のみAIを呼び出し
- APIエラー時はモック提案にフォールバック



## プロンプトについて
- **行動のみ出力させる**
- 抽象的にやりたいことを入力しても **具体的にやることを提案する** ように設定
- 本リリース後、行動のみをDBとして **達成・未達の管理ができるようにする** のも目的
- 気持ち・時間・障害に応じてプロンプトを分岐
- 行動の粒度調整
- ユーザー状態に応じた補助指示


## 再提案機能
- hidden_fieldで前回の入力値を保持
- 前回の提案をプロンプトに渡し、異なる提案を生成
- 同じ行動の再出力を防止



実装後:

## 背景・目的

実際にアプリを触ってみて、以下の課題を感じました:

- **時間の入力と障害の選択肢が不必要**
  - AI生成の結果を手助けするための設計になっていたが、ユーザー視点に立って設計し直す必要がある
  - 入力は最小限にし、ユーザーが **考えずに操作できる状態** を作る
  - AIは、その入力から **即実行可能な行動を1つに決定する**

### アプリの役割の再定義

何か始めたいけど、やる気が出ない時にどういう思考で動かせられるんだろう?と考え、このアプリの役割は **「意思決定を奪うこと」** だと認識しました。

- 何やるか迷う → 動けない
- 決まっている → 動ける

このアプリは気分を上げるアプリではなく、 **動かすことを目標にしたアプリ** です。
そのため、 **考えさせない設計** にする必要があります。

- 励ましで動くのではなく **決定で動く**
- マヨマヨが寄り添うコンセプトは、「その状態にあった一歩を出す」こと
- 現状の選択肢「何が邪魔しているか?」は、ユーザーに原因分析をさせて負担になる可能性がある

---

## 変更内容

### 1. 入力フォームの選択肢を変更

**変更前:**
1. 気になっていること(必須)
2. 今の気持ち(必須)
3. 今から使える時間(必須)
4. 何が邪魔しているか(必須)

**変更後:**
1. やりたいこと(必須)
2. 今どんな感じ?(必須)
3. 一歩の大きさ(難易度)(任意)

**理由:**
- 「何が邪魔しているか?」という選択肢は、ユーザーに原因分析をさせて負担になる可能性がある
- 入力を最小限にし、ユーザーが考えずに操作できる状態を作る

---

### 2. 結果出力画面のヘルパーとOPENAI生成の使い分け

**課題:**
- 行動のみの出力は冷たい印象かつアプリの「寄り添う」個性が消える
- 寄り添うを前面に出すと、読むのが面倒で結局行動につながらない

**解決策:**
- **OPENAIの生成結果** → 行動のみを出力
- **ヘルパー** → 選択肢によって短く「今の気分ならこれがちょうどいいよ」など一行のみの返答を出力

ヘルパーは感情的な励ましではなく、ユーザーが迷わず行動を選べるようにするための **「判断補助の一言」** として使用します。

---


## 次回ブランチでやるべき作業

- [ ] 選択肢を4 → 3に変更
- [ ] 結果出力画面のヘルパーを表示させる

---

## 補足

このブランチでは、プロンプトの設計と「もう一度提案する」機能の実装を行いました。
次回ブランチで、入力フォームの変更と結果出力画面のヘルパー表示を実装します