### PR TITLE
トップページ作成・入力フォームの修正

### DIFF
--- a/app/assets/stylesheets/static_pages.css
+++ b/app/assets/stylesheets/static_pages.css
@@ -1,0 +1,511 @@
+.lp-wrap {
+    font-family: Arial, sans-serif;
+    background-color: #FFF3D6;
+    color: #333;
+  }
+
+  /* ヒーロー */
+  .lp-hero {
+    text-align: center;
+    padding: 40px 16px 32px;
+  }
+
+  .lp-hero-badge {
+    display: inline-block;
+    background: #fff7f0;
+    color: #e76f51;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 14px;
+    border-radius: 999px;
+    border: 1.5px solid #f3d5b5;
+    margin-bottom: 20px;
+    letter-spacing: 0.03em;
+  }
+
+  .lp-hero-mascot {
+    height: 80px;
+    display: block;
+    margin: 0 auto 12px;
+    animation: lp-float 3s ease-in-out infinite;
+  }
+
+  @keyframes lp-float {
+    0%, 100% { transform: translateY(0); }
+    50%       { transform: translateY(-8px); }
+  }
+
+  .lp-hero h1 {
+    font-size: clamp(22px, 4vw, 30px);
+    font-weight: bold;
+    line-height: 1.65;
+    color: #333;
+    margin: 0 0 14px;
+  }
+
+  .lp-hero h1 .lp-accent {
+    background: linear-gradient(135deg, #e76f51, #f4a261);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .lp-hero-sub {
+    font-size: 14px;
+    line-height: 1.8;
+    color: #555;
+    margin-bottom: 28px;
+  }
+
+  .lp-hero-btns {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  /* 共通ボタン（steps.cssの.btn/.btn-secondaryを踏襲） */
+  .lp-btn {
+    background: linear-gradient(135deg, #f4a261, #e76f51);
+    color: white;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: 0.2s;
+    text-decoration: none;
+    display: inline-block;
+  }
+
+  .lp-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(231, 111, 81, 0.25);
+    text-decoration: none;
+    color: white;
+  }
+
+  .lp-btn-secondary {
+    background: transparent;
+    color: #e76f51;
+    border: 2px solid #e76f51;
+    padding: 10px 22px;
+    border-radius: 999px;
+    font-size: 14px;
+    text-decoration: none;
+    display: inline-block;
+    transition: 0.2s;
+  }
+
+  .lp-btn-secondary:hover {
+    background: #fff7f0;
+    color: #e76f51;
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+
+  /*区切り*/
+  .lp-divider {
+    text-align: center;
+    color: #bbb;
+    font-size: 12px;
+    padding: 4px 0 24px;
+  }
+
+  /* 使い方セクション */
+  .lp-how {
+    background: #fff7f0;
+    border-top: 1px dashed #f3d5b5;
+    border-bottom: 1px dashed #f3d5b5;
+    padding: 36px 16px;
+  }
+
+  .lp-section-title {
+    font-size: 16px;
+    font-weight: 700;
+    text-align: center;
+    color: #555;
+    margin: 0 0 24px;
+  }
+
+  .lp-steps {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    max-width: 640px;
+    margin: 0 auto;
+  }
+
+  .lp-step-card {
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 18px 14px;
+    text-align: center;
+    width: 150px;
+    border: 1.5px solid #f3d5b5;
+    box-shadow: 0 2px 8px rgba(231, 111, 81, 0.06);
+  }
+
+  .lp-step-num {
+    width: 24px;
+    height: 24px;
+    background: linear-gradient(135deg, #f4a261, #e76f51);
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: bold;
+    margin: 0 auto 10px;
+  }
+
+  .lp-step-icon { font-size: 26px; display: block; margin-bottom: 8px; }
+  .lp-step-label { font-size: 12px; font-weight: bold; color: #444; line-height: 1.5; }
+  .lp-step-desc  { font-size: 11px; color: #888; margin-top: 5px; line-height: 1.5; }
+
+  .lp-step-arrow {
+    font-size: 18px;
+    color: #f4a261;
+    display: flex;
+    align-items: center;
+    padding-top: 28px;
+  }
+
+  /* デモセクション*/
+  .lp-demo {
+    padding: 36px 16px;
+  }
+
+  .lp-demo-note {
+    text-align: center;
+    font-size: 12px;
+    color: #aaa;
+    margin: -16px 0 18px;
+  }
+
+  /* steps.cssの main-form を踏襲 */
+  .lp-demo-box {
+    max-width: 600px;
+    margin: 0 auto;
+    background-color: #ffffff;
+    padding: 28px;
+    border-radius: 20px;
+    border: 1.5px solid #f3d5b5;
+    box-shadow: 0 4px 16px rgba(231, 111, 81, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
+  }
+
+  /* mascot-bubble と同じスタイル */
+  .lp-demo-header {
+    background: #fffaf7;
+    border: 2px solid #f3d5b5;
+    border-radius: 14px;
+    padding: 14px 16px;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .lp-demo-header-icon { font-size: 22px; }
+
+  .lp-demo-header-text {
+    font-size: 14px;
+    font-weight: bold;
+    color: #555;
+  }
+
+  .lp-demo-label {
+    font-size: 12px;
+    font-weight: bold;
+    color: #555;
+    margin-bottom: 8px;
+    display: block;
+  }
+
+  .lp-demo-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+
+  /* status-btn を踏襲したチップ */
+  .lp-chip {
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1.5px solid #e8d8c3;
+    background: #fffaf7;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.2s;
+    color: #444;
+    font-weight: 500;
+  }
+
+  .lp-chip:hover {
+    transform: translateY(-1px);
+    background: #fff7f0;
+    border-color: #f4a261;
+    color: #c1440e;
+  }
+
+  .lp-chip.active {
+    background: #f4a261;
+    color: white;
+    border-color: #f4a261;
+    box-shadow: 0 4px 10px rgba(244, 162, 97, 0.25);
+  }
+
+  /* steps.cssのgoal-group textarea を踏襲 */
+  .lp-demo-input {
+    width: 100%;
+    color: #5a3e2b;
+    background-color: #fffef5;
+    border: 2px dashed #f4a261;
+    border-radius: 16px;
+    box-shadow: 3px 3px 0px #f3d5b5;
+    line-height: 1.6;
+    padding: 12px 14px;
+    font-size: 13px;
+    font-family: Arial, sans-serif;
+    box-sizing: border-box;
+    margin-bottom: 4px;
+    outline: none;
+    transition: 0.2s;
+    resize: none;
+  }
+
+  .lp-demo-input::placeholder { color: #c8b49a; }
+  .lp-demo-input:focus { border-color: #e76f51; box-shadow: 0 0 0 3px rgba(244, 162, 97, 0.15), 3px 3px 0px #f3d5b5; }
+
+  /* status-buttons を踏襲したムードボタン群 */
+  .lp-mood-btns {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  /* steps.cssの status-btn を踏襲 */
+  .lp-mood-btn {
+    padding: 12px 10px;
+    border-radius: 999px;
+    border: 1.5px solid #e8d8c3;
+    background: #fffaf7;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.2s;
+    color: #444;
+    font-weight: 500;
+    text-align: center;
+  }
+
+  .lp-mood-btn:hover {
+    transform: translateY(-1px);
+    background: #fff7f0;
+    border-color: #f4a261;
+    color: #c1440e;
+  }
+
+  .lp-mood-btn.active {
+    background: #f4a261;
+    color: white;
+    border-color: #f4a261;
+    box-shadow: 0 4px 10px rgba(244, 162, 97, 0.25);
+  }
+
+  /* steps.cssの .btn を踏襲 */
+  .lp-demo-run-btn {
+    width: 100%;
+    background: linear-gradient(135deg, #f4a261, #e76f51);
+    color: white;
+    padding: 13px 18px;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+    transition: 0.2s;
+    margin-top: 4px;
+  }
+
+  .lp-demo-run-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(231, 111, 81, 0.25);
+  }
+
+  .lp-demo-run-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  /* steps.cssの proposal-content を踏襲 */
+  .lp-result {
+    margin-top: 20px;
+    display: none;
+    animation: lp-pop 0.3s ease;
+  }
+
+  .lp-result.visible { display: block; }
+
+  @keyframes lp-pop {
+    from { opacity: 0; transform: scale(0.97); }
+    to   { opacity: 1; transform: scale(1); }
+  }
+
+  .lp-result-inner {
+    background: #fff7f0;
+    border-left: 4px solid #f4a261;
+    padding: 18px 20px;
+    margin-bottom: 16px;
+    line-height: 1.8;
+    font-size: 14px;
+    border-radius: 0 10px 10px 0;
+  }
+
+  .lp-result-label {
+    font-size: 11px;
+    font-weight: bold;
+    color: #e76f51;
+    margin-bottom: 8px;
+    letter-spacing: 0.05em;
+  }
+
+  .lp-result-step {
+    font-size: 16px;
+    font-weight: bold;
+    color: #333;
+    line-height: 1.6;
+    margin-bottom: 8px;
+  }
+
+  .lp-result-note {
+    font-size: 12px;
+    color: #888;
+    line-height: 1.6;
+  }
+
+  .lp-result-cta {
+    text-align: center;
+    font-size: 13px;
+    color: #888;
+    padding: 10px 0 0;
+  }
+
+  .lp-result-cta a {
+    color: #e76f51;
+    font-weight: bold;
+    text-decoration: none;
+  }
+
+  .lp-result-cta a:hover { text-decoration: underline; }
+
+  /* ローディングドット（steps.cssのthinking-animationを踏襲） */
+  .lp-loading-dots { display: inline-flex; gap: 3px; align-items: center; }
+  .lp-dot {
+    width: 7px; height: 7px;
+    background: #f4a261;
+    border-radius: 50%;
+    display: inline-block;
+    animation: lp-blink 1.4s infinite;
+  }
+  .lp-dot:nth-child(2) { animation-delay: 0.2s; }
+  .lp-dot:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes lp-blink {
+    0%, 100% { opacity: 0.3; }
+    50%       { opacity: 1; }
+  }
+
+  /* 価値セクション*/
+  .lp-value {
+    background: #fff7f0;
+    border-top: 1px dashed #f3d5b5;
+    padding: 36px 16px;
+  }
+
+  .lp-value-cards {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 20px;
+    max-width: 640px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .lp-value-card {
+    background: #ffffff;
+    border: 1.5px solid #f3d5b5;
+    border-radius: 16px;
+    padding: 18px 16px;
+    width: 180px;
+    text-align: center;
+    box-shadow: 0 2px 8px rgba(231, 111, 81, 0.06);
+  }
+
+  .lp-value-icon { font-size: 28px; display: block; margin-bottom: 8px; }
+
+  .lp-value-title {
+    font-size: 13px;
+    font-weight: bold;
+    color: #444;
+    margin-bottom: 6px;
+  }
+
+  .lp-value-desc { font-size: 11px; color: #888; line-height: 1.6; }
+
+  /* ========== CTAセクション ========== */
+  .lp-cta {
+    padding: 48px 16px;
+    text-align: center;
+  }
+
+  .lp-cta h2 {
+    font-size: 18px;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 10px;
+    line-height: 1.65;
+  }
+
+  .lp-cta-sub {
+    font-size: 13px;
+    color: #888;
+    margin-bottom: 22px;
+  }
+
+  /*フッター*/
+  .lp-footer {
+    background: #e76f51;
+    color: white;
+    text-align: center;
+    padding: 20px 16px;
+    font-size: 13px;
+  }
+
+  .lp-footer-logo {
+    font-size: 15px;
+    font-weight: bold;
+    margin-bottom: 4px;
+  }
+
+  .lp-footer-copyright {
+    font-size: 11px;
+    opacity: 0.8;
+  }
+
+  /* レスポンシブ  */
+  @media (max-width: 640px) {
+    .lp-step-arrow { display: none; }
+    .lp-step-card { width: 130px; }
+    .lp-value-card { width: 100%; max-width: 260px; }
+    .lp-demo-box { padding: 20px 14px; }
+  }
+
+  @media (max-width: 480px) {
+    .lp-mood-btns { grid-template-columns: 1fr; }
+  }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::Base
+  def after_sign_in_path_for(resource)
+    new_step_path
+  end
+
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def top
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -54,3 +54,6 @@ const initStepForm = () => {
 // ③ 初期化
 document.addEventListener("DOMContentLoaded", initStepForm);
 document.addEventListener("turbo:load", initStepForm);
+
+
+

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,139 @@
+<div class="lp-wrap">
+  <section class="lp-hero">
+      <span class="lp-hero-badge">🌱 いつかやりたいを、今日の一歩に変えよう</span>
+      <%= image_tag "mayomayo.png", class:"lp-hero-mascot"%>
+      <h1>
+       「やりたい」のに動けないとき、<br>
+        <span class="lp-accent">まよまよと一緒に今日やることを決めよう</span>
+      </h1>
+     <p class="lp-hero-sub">
+        やりたいことと今の気持ちを選ぶだけで、<br>
+        今日やることを1つだけ提案。迷わず動き出せる。
+     </p>
+     <div class="lp-hero-btns">
+       <a href="#lp-demo" class="lp-btn">🎮 デモを体験する</a>
+       <% if user_signed_in? %>
+         <%= link_to "さっそくはじめる →", new_step_path, class: "lp-btn-secondary" %>
+       <% else %>
+         <%= link_to "登録してはじめる →", new_user_registration_path, class: "lp-btn-secondary" %>
+       <% end %>
+     </div>
+  </section>
+
+  <p class="lp-divider">▼ こんなふうに使います</p>
+
+  <section class="lp-how">
+    <p class="lp-section-title">3ステップで「今日の一歩」が決まる</p>
+    <div class="lp-steps">
+      <div class="lp-step-card">
+        <div class="lp-step-num">1</div>
+        <span class="lp-step-icon">💭</span>
+        <div class="lp-step-label">やりたいことを入力</div>
+        <div class="lp-step-desc">料理・勉強・ランニングなど、なんでも</div>
+      </div>
+      <div class="lp-step-arrow">→</div>
+      <div class="lp-step-card">
+        <div class="lp-step-num">2</div>
+        <span class="lp-step-icon">🌡️</span>
+        <div class="lp-step-label">今の気分を選ぶ</div>
+        <div class="lp-step-desc">「ちょっとやりたい」「動きたいけど重い」など</div>
+      </div>
+      <div class="lp-step-arrow">→</div>
+      <div class="lp-step-card">
+        <div class="lp-step-num">3</div>
+        <span class="lp-step-icon">🌱</span>
+        <div class="lp-step-label">今日の一歩が決まる！</div>
+        <div class="lp-step-desc">今日やることが1つだけ決まります</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="lp-demo" id="lp-demo">
+    <p class="lp-section-title">🎮 デモを体験してみよう</p>
+    <p class="lp-demo-note">※ ログイン不要の疑似体験です（実際のAIは使用していません）</p>
+
+    <div class="lp-demo-box">
+
+      <div class="lp-demo-header">
+        <span class="lp-demo-header-icon">🌱</span>
+        <span class="lp-demo-header-text">まよまよと一緒に今日の一歩を決めよう</span>
+      </div>
+
+      <span class="lp-demo-label">「いつかやりたい」と思っていることを選んでみよう</span>
+      <div class="lp-demo-chips">
+        <span class="lp-chip" data-topic="料理を始めてみたい">🍳 料理を始めてみたい</span>
+        <span class="lp-chip" data-topic="英語を話せるようになりたい">📚 英語を話せるようになりたい</span>
+        <span class="lp-chip" data-topic="ランニングを習慣にしたい">🏃 ランニングを習慣にしたい</span>
+        <span class="lp-chip" data-topic="イラストを描いてみたい">🎨 イラストを描いてみたい</span>
+      </div>
+      <textarea class="lp-demo-input" id="lp-topic" rows="2"
+                placeholder="例: ギターを弾けるようになりたい、プログラミングを始めたい..." maxlength="50"></textarea>
+
+      <span class="lp-demo-label" style="margin-top:14px;">💭 今どんな感じ？</span>
+      <div class="lp-mood-btns">
+        <div class="lp-mood-btn" data-mood="light">気になっているだけ</div>
+        <div class="lp-mood-btn" data-mood="medium">ちょっとやりたい</div>
+        <div class="lp-mood-btn" data-mood="heavy">動きたいけど重い</div>
+        <div class="lp-mood-btn" data-mood="moody">なんとなくモヤモヤ</div>
+      </div>
+
+      <button class="lp-demo-run-btn" id="lp-run-btn" disabled>
+         今日の一歩を決める
+      </button>
+
+      <div class="lp-result" id="lp-result">
+        <div class="lp-result-inner">
+          <div class="lp-result-label">🌱 今日の一歩はこれ！</div>
+          <div class="lp-result-step" id="lp-result-step"></div>
+          <div class="lp-result-note" id="lp-result-note"></div>
+        </div>
+        <div class="lp-result-cta">
+          <% if user_signed_in? %>
+            <%= link_to "AIの本物の提案を試してみる →", new_step_path %>
+          <% else %>
+            <strong><%= link_to "登録すると記録が残ります ✨", new_user_registration_path %></strong>
+          <% end %>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <section class="lp-value">
+    <p class="lp-section-title">まよまよステップが選ばれる理由</p>
+    <div class="lp-value-cards">
+      <div class="lp-value-card">
+        <span class="lp-value-icon">🎯</span>
+        <div class="lp-value-title">迷いを排除</div>
+        <div class="lp-value-desc">提案は必ず1つだけ。「あれもこれも」と迷わなくていい。</div>
+      </div>
+      <div class="lp-value-card">
+        <span class="lp-value-icon">💬</span>
+        <div class="lp-value-title">すぐにできる具体的な提案</div>
+        <div class="lp-value-desc">「今すぐできる」レベルの具体的な行動だけを提案します</div>
+      </div>
+      <div class="lp-value-card">
+        <span class="lp-value-icon">📊</span>
+        <div class="lp-value-title">記録で成長を実感</div>
+        <div class="lp-value-desc">「今日もやれた」を積み重ね、自分の変化が見えてくる。</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="lp-cta">
+    <h2>さあ、いつかやりたいを<br>今日の一歩に変えよう 🌱</h2>
+    <p class="lp-cta-sub">メールアドレスだけで、すぐに始められます</p>
+    <% if user_signed_in? %>
+      <%= link_to "さっそく一歩を踏み出す →", new_step_path, class: "lp-btn", style: "font-size:15px; padding:14px 32px;" %>
+    <% else %>
+      <%= link_to "無料で始める ✨", new_user_registration_path, class: "lp-btn", style: "font-size:15px; padding:14px 32px;" %>
+    <% end %>
+  </section>
+
+  <footer class="lp-footer">
+    <p class="lp-footer-logo">まよまよステップ</p>
+    <p>やること、もう迷わなくていい。</p>
+    <p class="lp-footer-copyright">© 2026 まよまよステップ.</p>
+  </footer>
+
+</div><%# /.lp-wrap %>

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -12,12 +12,13 @@
               まよまよステップへようこそ！
             </p>
             <p class="bubble-text">
-              やること、もう迷わなくていい。<br>
-              今日やる一歩を1つに決めます🌱
+              「やりたいけど、できないまま」<br>
+              そんなこと、ありませんか？🌱<br>
             </p>
            <p class="how-to-use">
-              今の気持ちと、<br>やりたいことを入力するだけ。<br>
-              まよまよが、今日の一歩を見つけます。
+              <strong>「いつかやりたい」と思っていること</strong> を<br>
+              <strong>1つだけ</strong> 入力してね。<br>
+              まよまよと一緒に「それくらいならできそう♪」と思える一歩を決めよう。
            </p>
           </div>
       
@@ -25,9 +26,9 @@
         <div class="bubble-examples">
           <p class="examples-intro">例えば、こんなこと：</p>
            <ul class="examples-simple-list">
-               <li>料理がうまくなりたい</li>
-               <li>栄養について勉強したい</li>
-               <li>音楽を作ってみたい</li>
+               <li>料理を始めてみたい</li>
+               <li>英語を話せるようになりたい</li>
+               <li>ランニングを習慣にしたい</li>
             </ul>
         </div>
       </div>
@@ -48,15 +49,18 @@
     
     <div class="form-group goal-group">
       <%= f.label :goal, class: 'form-label' do %>
-         🌱気になっていること
+         🌱いつかやりたいこと
           <span class="required-badge">必須</span>
       <% end %>
 
       <%= f.text_area :goal, 
           class: 'form-control',
           rows: 3, 
-          placeholder: 'ここに書いてね', 
+          placeholder: '例：ギターを弾けるようになりたい、プログラミングを始めたい...',
           'aria-required': 'true' %>
+          <small class="form-text text-muted">
+           ※ 複数ある場合は、<strong>一番気になるもの1つ</strong> を書いてね
+          </small>
     </div>
 
      <div class="form-group">
@@ -79,7 +83,7 @@
     
     <div class="form-group">
        <%= f.label :time_available, class: 'form-label' do %>
-         ⌛一歩の大きさ
+         ⌛どれくらいできそう？
          <span class="required-badge">任意</span>
        <% end %>
        <%= f.hidden_field :time_available, id: "time-available-field" %>
@@ -96,7 +100,7 @@
     </div>
 
     <div class="form-actions">
-      <%= f.submit 'まよまよに相談する', class: 'btn btn-primary' %>
+      <%= f.submit '今日の一歩を決める', class: 'btn btn-primary' %>
     </div>
 
     <div id="loading-indicator" class="loading-indicator hidden">
@@ -108,7 +112,7 @@
             <span class="dot"></span>
           </div>
       </div>
-        <p class="loading-text">考え中...</p>
+        <p class="loading-text">一歩を決めています...</p>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'static_pages/top'
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -8,8 +9,8 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
-
-  root 'steps#new'
+  root 'static_pages#top'
+  get 'steps/new', to: 'steps#new', as: 'new_step'
   post 'steps/generate', to: 'steps#generate', as: 'generate_step'
   get 'steps/result', to: 'steps#result'
 

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get top" do
+    get static_pages_top_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
トップページの説明セクションを作成し、入力フォームのデザインを修正しました。

## 意図
- トップページでサービスの価値を分かりやすく伝えたい
- 使い方説明を充実させたい
- ログインなしでもサービスのイメージを掴んでもらいたい

## 変更内容
 - トップページ（`StaticPages#top`）の作成
   - ヒーローセクション
   - 使い方セクション（3ステップ）
   - デモセクション（次のissueで実装予定）
   - 価値セクション（選ばれる理由）
   - CTAセクション

## 修正
 - 入力フォームのテキスト修正


## 変更ファイル
- `app/controllers/static_pages_controller.rb`（新規作成）
- `app/views/static_pages/top.html.erb`（新規作成）
- `app/assets/stylesheets/static_pages.css`（新規作成）
- `config/routes.rb`
- `test/controllers/static_pages_controller_test.rb`（新規作成）

## このアプリのコンセプトの再確認
このアプリのコンセプトは **「やりたいことができないままの状態を脱却する」** ことです。


**ターゲットユーザー**

- やりたいことが色々あって迷っている人 ❌
- **やりたいことがあるのに、できないまま時間が過ぎている人** ✅

**目的**

- 「始め方がわからない」という認知的な問題の解決ではなく
- **「それくらいならやってみるか」という心理的なハードルを下げること**


### 今回の修正で解決した課題

#### 課題①：入力フォームに何を入力していいのかユーザーがつかみにくい

**問題点**
- 友人に触ってもらった際、想定とは違う内容を入力されてしまった
- 例：「ギターも麻雀も絵もうまくなりたい」（複数のことを列挙）

**想定していた入力内容**
- 「いつかやりたい」と思っていたことを **1つだけ** 入力
- 例：「手芸をやってみたい」「スパイスからカレーを作ってみたい」「歴史の勉強をやり直したい」

**対応内容**
- 入力フォームに **「いつかやりたいと思っていたことを1つだけ入力する」** という文言を追加

---

#### 課題②：文言がターゲットユーザーに刺さりにくい

**問題点**
- 現在の文言だと「やりたいことが色々あって迷っている人」に限定されてしまう
- 本来のターゲットである「やりたいことがあるのに、できないまま時間が過ぎている人」に刺さりにくい

**対応内容**
以下のような表現で、ターゲットユーザーに刺さる文言に修正しました。

**「できないまま」の状態に共感する表現**
   - 「やりたいけどできないまま」

---

#### 課題③：「相談」ではなく「決断」のニュアンスを強調

**問題点**
- 「料理がうまくなりたい」「英語を勉強したい」 → 悩み相談・目標設定っぽい
- 「転職を考えている」 → 相談事っぽい
- 「挑戦」「やってみたい」というワクワク感が薄い

**目指すべき方向性**
- **「いつかやってみたいこと」** というワクワク感
- **「始め方がわからない」** ではなく **「それくらいならやってみるか」**
- **「挑戦」「新しいこと」** というポジティブな印象

**対応内容**
- 「相談する」 → **「決める」** で、決断のニュアンスを強調
- ユーザー自身が決断する主体であることを明確に

**コンセプトの整理**
- 「相談」 → 悩みを聞いてもらう、アドバイスをもらう（受け身）❌
- 「決断」 → 今日やることを決める、一歩を踏み出す（能動的）✅
- **まよまよステップは「決断を助けるツール」**

---

### まとめ

今回の修正により、以下の点が改善されました。

- 入力フォームの意図が明確になった
- ターゲットユーザーに刺さる文言になった
- 「相談」ではなく「決断」のニュアンスが強調された

これにより、ユーザーが **「それくらいならやってみるか」** と感じ、行動のハードルを下げることができるようになりました。