### PR TITLE
Feature/74 proposal status

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -9,37 +9,21 @@ class ProposalsController < ApplicationController
                     current_user.proposals.accepted
                   when 'completed'
                     current_user.proposals.completed
-                  when 'skipped'
-                    current_user.proposals.skipped
                   else
-                    current_user.proposals.pending
+                    current_user.proposals.accepted
                   end.order(created_at: :desc)
    end
 
-    def pending
-      @proposal.pending!
-      redirect_to proposals_path, notice: '提案に戻しました'
-    rescue ActiveRecord::RecordInvalid
-      redirect_to proposals_path, alert: '更新に失敗しました'
-    end
-
     def accepted
       @proposal.accepted!
-      redirect_to proposals_path, notice: '一覧に追加しました！やってみよう🌱'
+      redirect_to proposals_path, notice: '提案を「実行中」に追加しました！'
     rescue ActiveRecord::RecordInvalid
-      redirect_to proposals_path, alert: '追加に失敗しました'
+      redirect_to proposals_path, alert: '更新に失敗しました'
     end
 
     def completed
       @proposal.completed!
       redirect_to proposals_path, notice: 'やったね！🎉'
-    rescue ActiveRecord::RecordInvalid
-      redirect_to proposals_path, alert: '更新に失敗しました'
-    end
-
-    def skipped
-      @proposal.skipped!
-      redirect_to proposals_path, notice: 'スキップしました'
     rescue ActiveRecord::RecordInvalid
       redirect_to proposals_path, alert: '更新に失敗しました'
     end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,6 +1,6 @@
 class ProposalsController < ApplicationController
     before_action :authenticate_user!
-    before_action :set_proposal, only: [:show, :pending, :accepted, :completed, :skipped, :destroy]
+    before_action :set_proposal, only: [:show, :accepted, :completed, :destroy]
 
   def index 
      @status_filter = params[:status] || 'accepted'

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -7,7 +7,7 @@ class Proposal < ApplicationRecord
   validates :reason, presence: true
   validates :action, presence: true
 
-  enum status: { pending: 0, accepted: 1, completed: 2, skipped: 3 }
+  enum status: { accepted: 0, completed: 1 }
   
   enum feeling: { 
     light_interest: 0, 

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -20,22 +20,16 @@
         <div class="pick-actions">
           <%= button_to 'やってみる', accepted_proposal_path(pick),
               method: :patch, class: 'btn-primary' %>
-          <%= button_to 'あとで', skipped_proposal_path(pick),
-              method: :patch, class: 'btn-subtle' %>
         </div>
       </div>
     </div>
   <% end %>
 
   <div class='status-filters'>
-    <%= link_to '提案リスト', proposals_path(status: 'pending'),
-        class: "filter-btn #{'active' if @status_filter == 'pending'}" %>
-    <%= link_to '今やってる', proposals_path(status: 'accepted'),
+    <%= link_to '実行中', proposals_path(status: 'accepted'),
         class: "filter-btn #{'active' if @status_filter == 'accepted'}" %>
     <%= link_to 'できた', proposals_path(status: 'completed'),
         class: "filter-btn #{'active' if @status_filter == 'completed'}" %>
-    <%= link_to '保留中', proposals_path(status: 'skipped'),
-        class: "filter-btn #{'active' if @status_filter == 'skipped'}" %>
   </div>
 
   <div class='proposal-cards'>
@@ -50,20 +44,12 @@
         </div>
 
         <div class='card-actions'>
-          <% if proposal.pending? %>
-            <%= button_to 'やる', accepted_proposal_path(proposal),
-                method: :patch, class: 'btn-primary btn-sm' %>
-          
-          <% elsif proposal.accepted? %>
+          <% if proposal.accepted? %>
             <%= button_to '完了', completed_proposal_path(proposal),
                 method: :patch, class: 'btn-success btn-sm' %>
 
           <% elsif proposal.completed? %>
             <span class='done-label'>✔ やれた</span>
-
-          <% elsif proposal.skipped? %>
-            <%= button_to '今ならやる', accepted_proposal_path(proposal),
-                method: :patch, class: 'btn-primary btn-sm' %>
           <% end %>
         </div>
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -33,20 +33,9 @@
     </div>
 
     <div class="detail-actions">
-      <% if @proposal.pending? %>
-        <%= button_to 'やってみる 🌱', accepted_proposal_path(@proposal),
-            method: :patch, class: 'btn-primary' %>
-        <%= button_to 'あとで', skipped_proposal_path(@proposal),
-            method: :patch, class: 'btn-subtle' %>
-            
-      <% elsif @proposal.accepted? %>
+      <% if @proposal.accepted? %>
         <%= button_to 'できた！', completed_proposal_path(@proposal),
             method: :patch, class: 'btn-success' %>
-            
-      <% elsif @proposal.skipped? %>
-        <%= button_to '今ならやる', accepted_proposal_path(@proposal),
-            method: :patch, class: 'btn-primary' %>
-            
       <% elsif @proposal.completed? %>
         <div class="completed-badge">
           <span class="badge-icon">✨</span>

--- a/app/views/steps/result.html.erb
+++ b/app/views/steps/result.html.erb
@@ -34,7 +34,8 @@
 
     <div class="primary-action">
       <%= button_to '✨やってみる', accepted_proposal_path(@proposal), 
-          method: :patch, class: 'btn-try' %>
+          method: :patch, 
+          class: 'btn-try' %>
     </div>
 
       <div class='secondary-actions'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,10 +25,8 @@ Rails.application.routes.draw do
 
   resources :proposals, only: [:index, :show, :destroy] do
     member do
-      patch :pending
       patch :accepted
       patch :completed
-      patch :skipped
     end
    end
 


### PR DESCRIPTION
## 概要
proposal のステータスを `pending`、`accepted`、`skipped`、`completed` の4つから、`accepted` と `completed` の2つに変更しました。

## 意図
提案一覧画面で、シンプルなほうがいいと判断したため、ステータスを実行中と完了で分けた。

## 変更内容
- `Proposal` モデルの enum を `accepted` と `completed` の2つに変更
- `ProposalsController` から `pending` と `skipped` 関連のアクションを削除
- `before_action` の `:only` オプションから `:pending` を削除
- `app/views/proposals/index.html.erb` から `pending` と `skipped` のフィルターを削除
- `app/views/proposals/show.html.erb` から `pending` と `skipped` の条件分岐を削除

## 動作確認
- [x] proposal 一覧ページで「やってみる」と「完了」のフィルターが表示されることを確認
- [x] 「やってみる」ボタンをクリックして、ステータスが `accepted` に変わることを確認
- [x] 「完了」ボタンをクリックして、ステータスが `completed` に変わることを確認
- [x] proposal 詳細ページで「できた！」ボタンが表示されることを確認
- [x] 「できた！」ボタンをクリックして、ステータスが `completed` に変わることを確認

## 補足
- マイグレーションファイルは変更していません（デフォルト値が `0` = `accepted` で問題ないため）