### PR TITLE
user_badgeモデルRSpec追加

### DIFF
--- a/spec/models/user_badge_spec.rb
+++ b/spec/models/user_badge_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe UserBadge, type: :model do
+  describe 'バリデーション' do
+    it 'userがない場合、無効である' do
+      user_badge = build(:user_badge, user: nil)
+      expect(user_badge).to be_invalid
+      expect(user_badge.errors[:user]).to include('を入力してください')
+    end
+
+    it 'badgeがない場合、無効である' do
+      user_badge = build(:user_badge, badge: nil)
+      expect(user_badge).to be_invalid
+      expect(user_badge.errors[:badge]).to include('を入力してください')
+    end
+  end
+
+  describe 'アソシエーション' do
+    it 'userに属している' do
+      user_badge = create(:user_badge)
+      expect(user_badge.user).to be_present
+    end
+
+    it 'badgeに属している' do
+      user_badge = create(:user_badge)
+      expect(user_badge.badge).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## 概要
UserBadge モデルに対する RSpec のテストコードを追加しました。
UserBadge モデルは User と Badge の多対多の関係を表現する中間テーブルです。

## 変更内容
- UserBadge モデルのバリデーションのテスト
  - user がない場合に無効であるテスト
  - badge がない場合に無効であるテスト
- UserBadge モデルのアソシエーションのテスト
  - user に属しているテスト
  - badge に属しているテスト

## テスト結果
```bash
$ docker compose exec web bundle exec rspec spec/models/user_badge_spec.rb
....

Finished in 1.17 seconds (files took 2.89 seconds to load)
4 examples, 0 failures