### PR TITLE
fix: proposal create paramsの構造修正

### DIFF
--- a/app/assets/stylesheets/pages/result.css
+++ b/app/assets/stylesheets/pages/result.css
@@ -193,7 +193,7 @@
   position: relative;
   z-index: 10;
   top: 10px;
-  margin-bottom: -24px;
+  margin-bottom: -18px;
   transition: transform 0.25s ease;
 }
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,6 +1,6 @@
 class ProposalsController < ApplicationController
     before_action :authenticate_user!
-    before_action :set_proposal, only: [:show, :accepted, :completed, :destroy]
+    before_action :set_proposal, only: [:show, :completed, :destroy]
 
   def index 
      @status_filter = params[:status] || 'accepted'
@@ -14,11 +14,15 @@ class ProposalsController < ApplicationController
                   end.order(created_at: :desc)
    end
 
-    def accepted
-      @proposal.accepted!
-      redirect_to proposals_path, notice: '提案を「実行中」に追加しました！'
-    rescue ActiveRecord::RecordInvalid
-      redirect_to proposals_path, alert: '更新に失敗しました'
+    def create
+      @proposal = current_user.proposals.build(proposal_params)
+      @proposal.status = :accepted
+
+      if @proposal.save
+        redirect_to proposals_path, notice: '提案を保存しました！やってみよう！'
+      else
+        redirect_to root_path, alert: '提案の保存に失敗しました'
+      end
     end
 
     def completed
@@ -51,5 +55,17 @@ class ProposalsController < ApplicationController
 
     def set_proposal
       @proposal = current_user.proposals.find(params[:id])
+    end
+
+    def proposal_params
+      params.require(:proposal).permit(
+        :goal,
+        :feeling,
+        :time_available,
+        :suggestion,
+        :empathy,
+        :reason,
+        :action
+      )
     end
 end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -34,13 +34,7 @@ class StepsController < ApplicationController
         status: :accepted
       )
 
-      if @proposal.save
         render :result
-      else
-      flash.now[:error] = '提案の保存に失敗しました'
-      render :new, status: :unprocessable_entity
-      end
-
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -18,7 +18,7 @@
         <small class="pick-goal">きっかけ：<%= pick.goal %></small>
 
         <div class="pick-actions">
-          <%= button_to '完了したよ', accepted_proposal_path(pick),
+          <%= button_to '完了したよ', completed_proposal_path(pick),
               method: :patch, class: 'btn-primary' %>
         </div>
       </div>

--- a/app/views/steps/result.html.erb
+++ b/app/views/steps/result.html.erb
@@ -38,9 +38,17 @@
       </div>
 
       <div class="primary-action">
-        <%= button_to 'やってみたい', accepted_proposal_path(@proposal), 
-            method: :patch, 
-            class: 'btn-try' %>
+        <%= form_with url: proposals_path, method: :post do %>
+          <%= hidden_field_tag "proposal[goal]", @proposal.goal %>
+          <%= hidden_field_tag "proposal[feeling]", @proposal.feeling %>
+          <%= hidden_field_tag "proposal[time_available]", @proposal.time_available %>
+          <%= hidden_field_tag "proposal[suggestion]", @proposal.suggestion %>
+          <%= hidden_field_tag "proposal[empathy]", @proposal.empathy %>
+          <%= hidden_field_tag "proposal[reason]", @proposal.reason %>
+          <%= hidden_field_tag "proposal[action]", @proposal.action %>
+
+          <%= submit_tag "やってみたい", class: 'btn-try' %>
+        <% end %>
       </div>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,9 +26,8 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
  end
 
-  resources :proposals, only: [:new, :index, :show, :destroy] do
+  resources :proposals, only: [:new, :index, :show, :create, :destroy] do
     member do
-      patch :accepted
       patch :completed
     end
    end


### PR DESCRIPTION
## 概要
提案を生成した時点でDBに保存されるため、すべて一覧画面に表示されてしまう問題を解決した。
提案結果生成画面で「やってみたい」ボタンを押したときのみDBに保存するよう変更した。

## 変更内容
- 提案生成時の自動保存を削除
- 「やってみたい」ボタン押下時にDBに保存する処理を実装
- フォームに `hidden_field_tag` を使用し、提案内容をパラメータとして送信

## 変更したファイル
- `app/controllers/steps_controller.rb` (提案生成時の保存処理を削除)
- `app/controllers/proposals_controller.rb` (保存処理を実装)
- `app/views/steps/result.html.erb` (フォームを修正)

## 動作確認
- [ ] 提案生成後、一覧画面に表示されないことを確認
- [ ] 「やってみたい」ボタン押下後、一覧画面に表示されることを確認
- [ ] 保存された提案の内容が正しいことを確認

## 備考
- `hidden_field_tag` を使用することで、`scope: :proposal` の問題を回避した