### PR TITLE
Feature/47 responsive

### DIFF
--- a/app/assets/stylesheets/pages/header.css
+++ b/app/assets/stylesheets/pages/header.css
@@ -59,10 +59,11 @@
 }
 
 .hamburger-line {
-  width: 30px;
-  height: 3px;
+  width: 22px;
+  height: 2px;
   background-color: white;
-  transition: all 0.3s;
+  border-radius: 999px;
+  transition: all 0.3s ease;
 }
 
 /* ハンバーガーメニューが開いているときのアニメーション */
@@ -82,9 +83,10 @@
 .hamburger-menu {
   position: fixed;
   top: 80px;
-  right: -300px; /* 初期状態は画面外 */
+  right: -300px; 
   width: 250px;
-  background-color: white;
+  border-radius: 20px 0 0 20px;
+  background: rgba(231, 111, 81, 0.5);
   box-shadow: -2px 0 10px rgba(0, 0, 0, 0.1);
   transition: right 0.3s ease-in-out;
   z-index: 1000;

--- a/app/assets/stylesheets/steps.css
+++ b/app/assets/stylesheets/steps.css
@@ -369,8 +369,17 @@ textarea::placeholder {
   .mascot-area {
     flex-direction: column;
     text-align: center;
+    gap: 12px;
   }
   
+  .mascot-img {
+    width: 90px;
+  }
+
+  .mascot-bubble {
+    padding: 16px 12px;
+  }
+
   .mascot-bubble::before,
   .mascot-bubble::after {
     display: none; /* 縦並びでは三角不要 */

--- a/app/assets/stylesheets/steps.css
+++ b/app/assets/stylesheets/steps.css
@@ -533,3 +533,25 @@ textarea::placeholder {
   font-weight: bold;
   margin: 0 5px;
 }
+
+/* 区切り線のスタイル */
+.hamburger-divider {
+  height: 1px;
+  background-color: #e0e0e0;
+  margin: 12px 0;
+}
+
+/* ハンバーガーメニュー内の主要ナビゲーション（スマホのみ表示） */
+.hamburger-main-nav {
+  display: block;
+}
+
+/* PC サイズ（768px 以上）では非表示 */
+@media (min-width: 768px) {
+  .hamburger-main-nav {
+    display: none;
+  }
+   .hamburger-divider {
+    display: none;
+  }
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -23,6 +23,14 @@
     <div class='hamburger-menu' id='hamburger-menu'>
       <% if user_signed_in? %>
         <nav class='hamburger-nav'>
+          <div class='hamburger-main-nav'>
+            <%= link_to '新しい提案', new_step_path, class: 'hamburger-link' %>
+            <%= link_to '提案一覧', proposals_path, class: 'hamburger-link' %>
+            <%= link_to 'バッジ一覧', badges_path, class: 'hamburger-link' %>
+          </div>
+          
+          <div class= 'hamburger-divider'></div>
+
           <%= link_to 'アカウント設定', edit_user_registration_path, class: 'hamburger-link' %>
           <%= link_to t('devise.shared.links.sign_out'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'hamburger-link' %>
         </nav>


### PR DESCRIPTION
## 実装内容

- ヘッダーのレスポンシブ対応を実装
- スマホサイズ（768px未満）でハンバーガーメニューを表示
- PC サイズ（768px以上）でハンバーガーメニュー内の主要ナビゲーションを非表示
- ハンバーガーメニュー内の区切り線の表示制御を追加

## 変更内容の詳細

### ビューファイル
- `app/views/shared/_header.html.erb` にハンバーガーメニュー用のナビゲーションを追加
- スマホ版のみ表示する主要ナビゲーション（新しい提案・提案一覧・バッジ一覧）をハンバーガーメニュー内に配置

### CSS
- `app/assets/stylesheets/steps.css` にレスポンシブ対応のスタイルを追加
- メディアクエリを使用して、PC サイズでハンバーガーメニュー内の主要ナビゲーションと区切り線を非表示に設定

## 確認項目

### スマホサイズ（768px未満）
- [x] ハンバーガーメニューボタンが表示される
- [x] ハンバーガーメニューを開くと主要ナビゲーションが表示される
- [x] 区切り線が表示される
- [x] アカウント設定・ログアウトが表示される

### PC サイズ（768px以上）
- [x] ヘッダーに主要ナビゲーションが表示される
- [x] ハンバーガーメニュー内の主要ナビゲーションが非表示になる
- [x] ハンバーガーメニュー内の区切り線が非表示になる
- [x] アカウント設定・ログアウトのみハンバーガーメニューに表示される