### PR TITLE
Fix/95 generation count on api call

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -33,6 +33,8 @@ class StepsController < ApplicationController
         action: result[:action],
         status: :accepted
       )
+      
+      current_user.increment_generation_count!
 
         render :result
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,16 +10,20 @@ class User < ApplicationRecord
 
   DAILY_PROPOSAL_LIMIT = 10
 
-  def today_proposals_count
-    proposals.where('created_at >= ?', Time.current.beginning_of_day).count
-  end
-
-  def remaining_proposals_count
-    [DAILY_PROPOSAL_LIMIT - today_proposals_count, 0].max
+  def increment_generation_count!
+    reset_count_if_new_day
+    increment!(:daily_generation_count)
+    update_column(:last_generation_date, Date.current)
   end
 
   def reached_daily_limit?
-    today_proposals_count >= DAILY_PROPOSAL_LIMIT
+    reset_count_if_new_day
+    daily_generation_count >= DAILY_PROPOSAL_LIMIT
+  end
+
+  def remaining_proposals_count
+    reset_count_if_new_day
+    [DAILY_PROPOSAL_LIMIT - daily_generation_count, 0].max
   end
 
   def self.from_omniauth(auth)
@@ -28,6 +32,17 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[0, 20]
       # user.name = auth.info.name
       # user.image = auth.info.image
+    end
+  end
+
+  private
+
+  def reset_count_if_new_day
+    if last_generation_date != Date.current
+      update_columns(
+        daily_generation_count: 0,
+        last_generation_date: Date.current
+      )
     end
   end
 end

--- a/db/migrate/20260530101551_add_generation_count_to_users.rb
+++ b/db/migrate/20260530101551_add_generation_count_to_users.rb
@@ -1,0 +1,6 @@
+class AddGenerationCountToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :daily_generation_count, :integer, default: 0, null: false
+    add_column :users, :last_generation_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_21_080252) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_30_101551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_21_080252) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.integer "daily_generation_count", default: 0, null: false
+    t.date "last_generation_date"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,51 +87,26 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#today_proposals_count' do
-    it '今日の提案数を返す' do
-      user = create(:user)
-      create_list(:proposal, 3, :created_today, user: user)
-
-      expect(user.today_proposals_count).to eq(3)
-    end
-
-    it '昨日の提案は含まれないこと' do
-      user = create(:user)
-      create_list(:proposal, 2, :created_today, user: user)
-      create_list(:proposal, 3, :created_yesterday, user: user)
-
-      expect(user.today_proposals_count).to eq(2)
-    end
-
-    it '他のユーザーの提案は含まれないこと' do
-      user1 = create(:user)
-      user2 = create(:user)
-      create_list(:proposal, 3, :created_today, user: user1)
-      create_list(:proposal, 5, :created_today, user: user2)
-
-      expect(user1.today_proposals_count).to eq(3)
-    end
-  end
 
   describe '#remaining_proposals_count' do
     context '1日あたりの提案制限（10件）' do
       it '残り提案可能数を返すこと' do
         user = create(:user)
-        create_list(:proposal, 3, :created_today, user: user)
+        user.update!(daily_generation_count: 3, last_generation_date: Date.current)
 
         expect(user.remaining_proposals_count).to eq(7)
       end
 
       it '上限に達したら0を返すこと' do
         user = create(:user)
-        create_list(:proposal, 10, :created_today, user:user)
+        user.update!(daily_generation_count: 10, last_generation_date: Date.current)
 
         expect(user.remaining_proposals_count).to eq(0)
       end
 
       it '残り件数は0未満にならないこと' do
         user = create(:user)
-        create_list(:proposal, 11, :created_today, user:user)
+        user.update!(daily_generation_count: 11, last_generation_date: Date.current)
 
         expect(user.remaining_proposals_count).to eq(0)
       end
@@ -142,30 +117,49 @@ RSpec.describe User, type: :model do
     context '1日あたりの提案制限（10件）' do
       it '上限未満ならfalseを返すこと' do
         user = create(:user)
-        create_list(:proposal, 9, :created_today, user: user)
+        user.update!(daily_generation_count: 9, last_generation_date: Date.current)
 
         expect(user.reached_daily_limit?).to be false
       end
 
       it '上限に達したらtrueを返すこと' do
         user = create(:user)
-        create_list(:proposal, 10, :created_today, user: user)
+        user.update!(daily_generation_count: 10, last_generation_date: Date.current)
 
         expect(user.reached_daily_limit?).to be true
       end
 
       it '上限を超えたらtrueを返すこと' do
         user = create(:user)
-        create_list(:proposal, 11, :created_today, user: user)
+        user.update!(daily_generation_count: 11, last_generation_date: Date.current)
 
         expect(user.reached_daily_limit?).to be true
       end
 
-      it '提案が0件ならfalseを返すこと' do
+      it '生成回数が0件ならfalseを返すこと' do
         user = create(:user)
 
         expect(user.reached_daily_limit?).to be false
       end
+    end
+  end
+
+  describe '#increment_generation_count!' do
+    it '生成回数が1増えること' do
+      user = create(:user)
+      
+      expect{user.increment_generation_count!}.to change{user.reload.daily_generation_count}.from(0).to(1)
+    end
+  end
+
+  describe '日付変更時のリセット' do
+    it '前日のカウントをリセットすること' do
+      user = create(:user, daily_generation_count: 10, last_generation_date: Date.yesterday)
+
+      expect(user.remaining_proposals_count).to eq(10)
+      user.reload
+
+      expect(user.daily_generation_count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## 概要
AIの1日あたりの使用制限を、Proposal保存時ではなくAPI呼び出し時にカウントするよう修正

## 現状
目標を生成したあと「やってみる」をクリックしないと当日の生成回数がカウントされない状態になっている。
「他の提案も見る」や元のページに戻って再生成をするとAPIを叩けてしまう。

本来はユーザーが「やってみる」を選択したかどうかに関わらず生成した瞬間にカウントを進め、不要なAPIリクエストが発生しないようにすることが目的であるため、
- 生成APIを叩いた時点で即座にカウントを増やす
- 「やってみる」をクリックしたかどうかに関わらずカウントする
ように修正をする。

## userテーブルのカラムの追加
現状proposalコントローラでカウントしているため、保存されたレコードしかカウントできない
userテーブルでカウントする必要があるため、カラムを追加

①daily_generation_count カラム
役割： 今日の生成回数を記録

②last_generation_date カラム
役割： 最後に生成した日付を記録

提案生成はstepコントローラ（DB保存はproposalコントローラ）で行うため、使用制限のアクションはstepコントローラで行い、userテーブルでカウントの制限をする。


## 実装内容

### 1. データベース変更
- `users` テーブルに以下のカラムを追加
  - `daily_generation_count`: 1日あたりの生成回数を記録（デフォルト: 0）
  - `last_generation_date`: 最後に生成した日付を記録

### 2. User モデルの実装
- **`increment_generation_count!`**: 生成回数をカウントアップ
  - 日付が変わった場合は自動的にリセット
- **`remaining_proposals_count`**: 残り生成可能回数を返す
- **`reached_daily_limit?`**: 上限に達しているかを判定

### 3. Steps コントローラーの修正
* `generate` 実行前に利用回数上限をチェック
* AI生成成功時に生成回数を加算
* Proposal保存有無に依存せず回数制限を適用


###  4. テストコードの実装
Userモデルのテストを新しい回数管理方式に合わせて修正

#### テスト内容

* 生成回数のカウントアップ
* 残り回数の計算
* 上限判定
* 日付変更時のリセット

# 動作確認

* [x] AI生成時に生成回数がカウントされること
* [x] 「他の提案も見る」を実行しても生成回数がカウントされること
* [x] 10回生成後、11回目は生成できないこと
* [x] Userモデルのテストが成功すること

